### PR TITLE
Fix example config motor_load()

### DIFF
--- a/esphome/components/tmc2209/README.md
+++ b/esphome/components/tmc2209/README.md
@@ -310,7 +310,7 @@ number:
 sensor:
   - platform: template
     name: Estimated motor load
-    lambda: return id(driver)->motor_load();
+    lambda: return id(driver)->get_motor_load();
     update_interval: 100ms
 ```
 

--- a/esphome/components/tmc2209/README.md
+++ b/esphome/components/tmc2209/README.md
@@ -308,9 +308,9 @@ number:
           target: !lambda "return x;"
 
 sensor:
-  - platform: template
-    name: Estimated motor load
-    lambda: return id(driver)->get_motor_load();
+  - platform: tmc2209
+    type: motor_load
+    name: Motor load
     update_interval: 100ms
 ```
 


### PR DESCRIPTION
Seem like motor_load() was changed to get_motor_load() in commit #a893b85
Not sure if more references need changing in the actual code for example when using:
```yaml
sensor:
  - platform: tmc2209
    type: motor_load
    name: Motor load
    update_interval: 100ms
```
But i did not get any compile errors from using it?