### PR TITLE
Fix typo in TMC2209 README for direction option

### DIFF
--- a/esphome/components/tmc2209/README.md
+++ b/esphome/components/tmc2209/README.md
@@ -341,7 +341,7 @@ on_...:
 
 * `id` (**Required**, [ID][config-id]): Reference to the stepper tmc2209 component. Can be left out if only a single TMC2209 is configured.
 
-* `direction` (*Optional*, string, [templatable][config-templatable]): Effectively inverse the rotational direction. Options are `clockwise` or `counterclockwise` and their abbreviations `cw` or `cww`.
+* `direction` (*Optional*, string, [templatable][config-templatable]): Effectively inverse the rotational direction. Options are `clockwise` or `counterclockwise` and their abbreviations `cw` or `ccw`.
 
 * `microsteps` (*Optional*, int, [templatable][config-templatable]): Microstepping. Possible values are `1`, `2`, `4`, `8`, `16`, `32`, `64`, `128`, `256`.
 


### PR DESCRIPTION
In the README for TMC2209, the "counterclockwise" abbreviation was misspelled as "cww" when it should be "ccw". This fixes that typo.